### PR TITLE
Added the crontab ability to schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,36 +27,16 @@ cp itsdown/config.example.ini itsdown/config.ini
 python itsdown/main.py \
     --url "https://structpred.dash.materialsproject.org/report/hours/24/" \
     --fn "itsdown.functions.fwsdash_24hr" \
-    --to dwinston@lbl.gov
+    --to dwinston@lbl.gov \
+    --cron-expr "0 13 * * *"
 ```
+###<i>Note</i>
 
-## Advanced installation
+Crontab will not work if you have the normal crontab library installed. Please create a new environment or uninstall the normal crontab
+and download the python-crontab. Please check the documentation right [here.](https://pypi.org/project/python-crontab/)
 
-In addition to the above, you can use [Celery](http://www.celeryproject.org/) to run reports in a crontab-like manner.
+###Update
 
-You'll need to install [RabbitMQ](https://www.rabbitmq.com/) (Celery's recommended so-called "data broker"):
-```
-# Ubuntu/Debian?
-sudo apt-get install rabbitmq-server
-# Docker?
-docker run -d -p 5462:5462 rabbitmq
-# Homebrew?
-brew install rabbitmq
-```
-
-# Usage Example
-
-Start the RabbitMQ server:
-
-```
-# For example, if you use `brew install` on a Mac, this will ensure rabbitmq starts now and on system restarts.
-brew services start rabbitmq
-```
-
-Start the Celery server:
-
-```
-celery -A itsdown.tasks worker -l info
-```
-
-(Under construction) Use `celery.schedules.crontab` to do great things! 
+We removed the Celery and RabbitMQ for scheduling and instead use the python-crontab library.
+One reason is because it is harder to setup. In most cases Celery and RabbitMQ
+offers a lot more, though those features aren't needed in this type of application.

--- a/itsdown/main.py
+++ b/itsdown/main.py
@@ -6,9 +6,9 @@ from crontab import CronTab
 import os ; import subprocess
 dirpath = os.getcwd()
 dirpath = dirpath.replace("itsdown/itsdown", "itsdown")
-pypath = subprocess.Popen(['which','python'],stdout = subprocess.PIPE).communicate()[0].decode('ascii')
-pypath = pypath.replace("/python", "")
-
+# pypath = subprocess.Popen(['which','python'],stdout = subprocess.PIPE).communicate()[0].decode('ascii')
+# pypath = pypath.replace("/python", "")
+pypath = "/Users/destrada/miniconda3/envs/itsdown/bin/python"
 if __name__ == "__main__":
     cron = CronTab(user=True)
 
@@ -47,7 +47,7 @@ if __name__ == "__main__":
         #TODO make the python path dynamic
         sched=str(args.cron_expr).strip()
         job = cron.new(
-            command=f'cd {dirpath}/itsdown/ && /Users/destrada/miniconda3/envs/itsdown/bin/python '
+            command=f'cd {dirpath}/itsdown/ && {pypath} '
                     f'{dirpath}/itsdown/tasks.py {url} "{fn}" {to} >> {dirpath}/itsdown/printed_out.log')
         # >> {dirpath} / itsdown / printed_out.log
         # job.setall(sched)

--- a/itsdown/tasks.py
+++ b/itsdown/tasks.py
@@ -1,29 +1,15 @@
 from bs4 import BeautifulSoup
 import pdfkit
 import requests
-from celery import Celery
-
 from itsdown.send_email import send_email
+import sys
 
-app = Celery(
-    'itsdown',
-    broker='pyamqp://guest@localhost//',
-    backend='rpc://',
-    include=['itsdown.tasks']
-)
-
-# Optional configuration, see the application user guide.
-app.conf.update(
-    result_expires=3600,
-)
-
-
-@app.task
 def check_page(url, fn, to):
     rv = requests.get(url)
     page_as_string = rv.text
     print("Generating snapshot PDF of page in case problematic status is found...")
-    snapshot_pdf = pdfkit.from_url(url, False, options={"quiet": ""})
+    snapshot_pdf = pdfkit.from_url(url, False, options={"quiet": ''})
+    print("Normal")
     print(f"Done generating PDF. Analyzing page content with {fn}...")
     soup = BeautifulSoup(page_as_string, "html.parser")
     status = fn(soup)
@@ -34,3 +20,8 @@ def check_page(url, fn, to):
     print(f"Problematic status: '{status}'. Sending report to {to}...")
     send_email(recipient=to, url=url, status=status, attachment=snapshot_pdf)
     return {"problematic_status": True}
+
+if __name__ == "__main__":
+    url, fn, to = sys.argv[1:]
+    if url:
+        check_page(url,fn,to)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4==4.7.1
-celery==4.3.0
+python-crontab==2.3.8
 pdfkit==0.6.1
 requests==2.22.0


### PR DESCRIPTION
1. Need to change the python path from static to dynamic. Because Python path is used in python-crontab to execute python scripts.
2. Removed Celery and Rabbitmq and use the Python-Crontab for scheduling.
3. Crontab expression is now available as an argument to schedule checks.